### PR TITLE
Escape dbl quote and handle empty selecta result.

### DIFF
--- a/plugin/selecta.vim
+++ b/plugin/selecta.vim
@@ -14,12 +14,14 @@ function! SelectaCommand(choice_command, selecta_args, vim_command)
     return
   endtry
   redraw!
-  exec a:vim_command . " " . selection
+  if selection != ''
+    exec a:vim_command . " " . selection
+  endif
 endfunction
 
 function! SelectaFromList(choices, selecta_args, vim_command)
   let non_blank_choices = filter(a:choices, 'v:val !=""')
-  call SelectaCommand('echo "' . join(non_blank_choices, "\n") . '"', a:selecta_args, a:vim_command)
+  call SelectaCommand('echo "' . escape(join(non_blank_choices, "\n"), '"') . '"', a:selecta_args, a:vim_command)
 endfunction
 
 function! SelectaFile()


### PR DESCRIPTION
Hi,

There were two issues I noticed.

First issue:
1. Start a fresh copy of Vim and don't open any files.
2. `:call SelectaFile()`
3. Hit _Escape_ or any keystroke that cancels selecta without selecting a file.

The result is this error:

```
Error detected while processing function SelectaFile..SelectaCommand:
line   10:
E32: No file name
```

Second issue:
1. Run a command that leaves a double quote character in command history, e.g. `:echo '"'`
2. `:call SelectaHistoryCommand()`

The result is this error, although it varies depending on what comes after the double quote character:

```
Error detected while processing function SelectaHistoryCommand..SelectaFromList..SelectaCommand:
line    2:
E484: Can't open file /var/folders/mq/llkx61wn0zl1gr5jydzv8gq80000gn/T/vYV0fFg/5
```

This patch handles the empty selecta result from the first issue and escapes double quote characters to take care of the second issue.
