### PR TITLE
Configurable find parameters

### DIFF
--- a/doc/selecta.txt
+++ b/doc/selecta.txt
@@ -59,12 +59,18 @@ COMMANDS                                            *selecta-commands*
 VARIABLES                                          *selecta-variables*
 
                                                        *SelectaIgnore*
-Values: a list of partial file names.
-Default: ['.git/'].
+Values: a list of partial file names
+Default: [".git/"]
 
 This variable lists path patterns to ignore when finding files. A
 file is excluded from the selection list if it includes any of these
 strings anywhere in the path. Wildcards are accepted as per find(1).
+
+                                                     *SelectaFindRoot*
+Value: a file path
+Default: "."
+
+This variable is used as the root for all find commands.
 
 
 ISSUES                                                *selecta-issues*

--- a/doc/selecta.txt
+++ b/doc/selecta.txt
@@ -56,6 +56,17 @@ COMMANDS                                            *selecta-commands*
 :SelectaHistoryCommand    Find previously run commands. Fuzzy select
                           one of those. Run that command with :
 
+VARIABLES                                          *selecta-variables*
+
+                                                       *SelectaIgnore*
+Values: a list of partial file names.
+Default: ['.git/'].
+
+This variable lists path patterns to ignore when finding files. A
+file is excluded from the selection list if it includes any of these
+strings anywhere in the path. Wildcards are accepted as per find(1).
+
+
 ISSUES                                                *selecta-issues*
 
 File issues here: https://github.com/michaelavila/selecta.vim/issues

--- a/plugin/selecta.vim
+++ b/plugin/selecta.vim
@@ -1,7 +1,11 @@
 " Always ignore the following directories
-let SelectaIgnore = [".git/"]
+if !exists("g:SelectaIgnore")
+  let SelectaIgnore = [".git/"]
+endif
 " Use this as the root for finding files
-let SelectaFindRoot = "."
+if !exists("g:SelectaFindRoot")
+  let SelectaFindRoot = "."
+endif
 
 function! GetFindExcludes()
   return join(map(copy(g:SelectaIgnore), '"-not -path \"*" . v:val . "*\""'))

--- a/plugin/selecta.vim
+++ b/plugin/selecta.vim
@@ -1,5 +1,7 @@
 " Always ignore the following directories
 let SelectaIgnore = [".git/"]
+" Use this as the root for finding files
+let SelectaFindRoot = "."
 
 function! GetFindExcludes()
   return join(map(copy(g:SelectaIgnore), '"-not -path \"*" . v:val . "*\""'))
@@ -28,15 +30,15 @@ function! SelectaFromList(choices, selecta_args, vim_command)
 endfunction
 
 function! SelectaFile()
-  call SelectaCommand('find . -type f ' . GetFindExcludes(), '', ':e')
+  call SelectaCommand('find ' . g:SelectaFindRoot . ' -type f ' . GetFindExcludes(), '', ':e')
 endfunction
 
 function! SelectaVsplit()
-  call SelectaCommand('find . -type f ' . GetFindExcludes(), '', ':vsplit') 
+  call SelectaCommand('find ' . g:SelectaFindRoot . ' -type f ' . GetFindExcludes(), '', ':vsplit') 
 endfunction
 
 function! SelectaSplit()
-  call SelectaCommand('find . -type f ' . GetFindExcludes(), '', ':split') 
+  call SelectaCommand('find ' . g:SelectaFindRoot . ' -type f ' . GetFindExcludes(), '', ':split') 
 endfunction
 
 function! SelectaBuffer()

--- a/plugin/selecta.vim
+++ b/plugin/selecta.vim
@@ -1,6 +1,9 @@
 " Always ignore the following directories
 let ignore = [".git/"]
-let excludes=join(map(ignore, '"-not -path \"*" . v:val . "*\""'))
+
+function! GetFindExcludes()
+  return join(map(copy(g:ignore), '"-not -path \"*" . v:val . "*\""'))
+endfunction
 
 " Run a given vim command on the results of fuzzy selecting from a given shell
 " command. See usage below.
@@ -25,15 +28,15 @@ function! SelectaFromList(choices, selecta_args, vim_command)
 endfunction
 
 function! SelectaFile()
-  call SelectaCommand('find . -type f ' . g:excludes, '', ':e')
+  call SelectaCommand('find . -type f ' . GetFindExcludes(), '', ':e')
 endfunction
 
 function! SelectaVsplit()
-  call SelectaCommand('find . -type f ' . g:excludes, '', ':vsplit') 
+  call SelectaCommand('find . -type f ' . GetFindExcludes(), '', ':vsplit') 
 endfunction
 
 function! SelectaSplit()
-  call SelectaCommand('find . -type f ' . g:excludes, '', ':split') 
+  call SelectaCommand('find . -type f ' . GetFindExcludes(), '', ':split') 
 endfunction
 
 function! SelectaBuffer()

--- a/plugin/selecta.vim
+++ b/plugin/selecta.vim
@@ -1,8 +1,8 @@
 " Always ignore the following directories
-let ignore = [".git/"]
+let SelectaIgnore = [".git/"]
 
 function! GetFindExcludes()
-  return join(map(copy(g:ignore), '"-not -path \"*" . v:val . "*\""'))
+  return join(map(copy(g:SelectaIgnore), '"-not -path \"*" . v:val . "*\""'))
 endfunction
 
 " Run a given vim command on the results of fuzzy selecting from a given shell


### PR DESCRIPTION
Give users an easy way to override ignores and find root.

This pull request exposes and documents SelectaIgnore and SelectaFindRoot to override the ignore list and the root of find commands. The ignore list was previously in the variable "ignore", but it couldn't be overridden. The find root was hardcoded to ".".