### PR TITLE
Ignore .gitignore files by default

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -1,9 +1,12 @@
 SelectaBuffer	selecta.txt	/*SelectaBuffer*
 SelectaFile	selecta.txt	/*SelectaFile*
+SelectaFindRoot	selecta.txt	/*SelectaFindRoot*
 SelectaHistoryCommand	selecta.txt	/*SelectaHistoryCommand*
+SelectaIgnore	selecta.txt	/*SelectaIgnore*
 selecta	selecta.txt	/*selecta*
 selecta-commands	selecta.txt	/*selecta-commands*
 selecta-issues	selecta.txt	/*selecta-issues*
 selecta-license	selecta.txt	/*selecta-license*
 selecta-usage	selecta.txt	/*selecta-usage*
+selecta-variables	selecta.txt	/*selecta-variables*
 selecta.txt	selecta.txt	/*selecta.txt*

--- a/plugin/selecta.vim
+++ b/plugin/selecta.vim
@@ -1,6 +1,9 @@
 " Always ignore the following directories
 if !exists("g:SelectaIgnore")
   let SelectaIgnore = [".git/"]
+  if filereadable(".gitignore")
+    let SelectaIgnore = SelectaIgnore + readfile(".gitignore")
+  endif
 endif
 " Use this as the root for finding files
 if !exists("g:SelectaFindRoot")


### PR DESCRIPTION
Not sure if this is the best way to handle this -- I was seeing a bunch of `node_modules/`, `.cabal-sandbox`, etc. stuff in my results that wasn't useful. This modification works well for me, but if there's a better way I'm happy to make any modifications
